### PR TITLE
k8s: add external-dns

### DIFF
--- a/k8s/stack.yaml
+++ b/k8s/stack.yaml
@@ -124,7 +124,7 @@ appProject:
           wave: "-1"
       external-dns:
         namespace:
-          name: external-secrets
+          name: external-dns
         sync:
           autoSync: true
           wave: "-3"

--- a/k8s/stack.yaml
+++ b/k8s/stack.yaml
@@ -122,6 +122,12 @@ appProject:
         sync:
           autoSync: true
           wave: "-1"
+      external-dns:
+        namespace:
+          name: external-secrets
+        sync:
+          autoSync: true
+          wave: "-3"
       external-secrets:
         namespace:
           name: external-secrets

--- a/k8s/system/external-dns/Chart.yaml
+++ b/k8s/system/external-dns/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: external-dns
+description: ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers
+
+type: application
+
+version: 1.0.0
+
+dependencies:
+- name: external-dns
+  version: 0.13.2
+  repository: https://kubernetes-sigs.github.io/external-dns/

--- a/k8s/system/external-dns/templates/external-secrets.yml
+++ b/k8s/system/external-dns/templates/external-secrets.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-credentials
+spec:
+  secretStoreRef:
+    name: homelab
+    kind: ClusterSecretStore
+  refreshInterval: "8760h" # Once each year, pretty static secrets. Will manually decrease secret when i need it to refresh.
+  target:
+    name: cloudflare-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+  - extract:
+      key: homelab-cloudflare

--- a/k8s/system/external-dns/values.yaml
+++ b/k8s/system/external-dns/values.yaml
@@ -1,0 +1,18 @@
+external-dns:
+  provider: cloudflare
+  domainFilters:
+    - fmlab.no
+  interval: 168h
+  triggerLoopOnEvent: true
+  env:
+    - name: CF_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: cloudflare-credentials
+          key: api_token
+    - name: CF_API_EMAIL
+      valueFrom:
+        secretKeyRef:
+          name: cloudflare-credentials
+          key: email
+  sources: [] # Disable service/ingress in favor of CRDs


### PR DESCRIPTION
Makes it possible to create DNS records in Cloudflare using CRDs, which is useful for applications which will be available outside our internal network.