### PR TITLE
k8s: bump external-dns version

### DIFF
--- a/k8s/system/external-dns/Chart.yaml
+++ b/k8s/system/external-dns/Chart.yaml
@@ -8,5 +8,5 @@ version: 1.0.0
 
 dependencies:
 - name: external-dns
-  version: 0.13.2
+  version: 0.13.1
   repository: https://kubernetes-sigs.github.io/external-dns/


### PR DESCRIPTION
0.13.2 was a working branch, not present in helm index.