### PR TITLE
k8s: bump external-dns again

### DIFF
--- a/k8s/system/external-dns/Chart.yaml
+++ b/k8s/system/external-dns/Chart.yaml
@@ -8,5 +8,5 @@ version: 1.0.0
 
 dependencies:
 - name: external-dns
-  version: 0.13.1
-  repository: https://kubernetes-sigs.github.io/external-dns/
+  version: 1.12.0
+  repository: https://kubernetes-sigs.github.io/external-dns


### PR DESCRIPTION
Ran helm dependency build to figure out the version, might need to add some tests to github for verifying that all is good.