### PR TITLE
k8s: external-dns should only monitor traefik-external objects

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.9
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.tls: 'true'
     {{- end }}
     traefik.ingress.kubernetes.io/router.middlewares: "{{ .Values.ingresses.className }}-security@kubernetescrd"
+    {{- if eq .Values.ingresses.className "traefik-external" }}
+    external-dns.alpha.kubernetes.io/target: "vpn.fmlab.no" # Create CNAME instead of A record
+    {{- end }}
     {{- with .Values.ingresses.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.middlewares: "{{ .Values.ingresses.className }}-security@kubernetescrd"
     {{- if eq .Values.ingresses.className "traefik-external" }}
     external-dns.alpha.kubernetes.io/target: "vpn.fmlab.no" # Create CNAME instead of A record
+    kubernetes.io/ingress.class: traefik-external # Annotation filter for external-dns
     {{- end }}
     {{- with .Values.ingresses.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/k8s/system/external-dns/values.yaml
+++ b/k8s/system/external-dns/values.yaml
@@ -17,3 +17,5 @@ external-dns:
           key: email
   extraArgs:
     - --annotation-filter=kubernetes.io/ingress.class in (traefik-external)
+  sources:
+    - ingress

--- a/k8s/system/external-dns/values.yaml
+++ b/k8s/system/external-dns/values.yaml
@@ -15,4 +15,5 @@ external-dns:
         secretKeyRef:
           name: cloudflare-credentials
           key: email
-  sources: [] # Disable service/ingress in favor of CRDs
+  args:
+    - --annotation-filter=kubernetes.io/ingress.class in (traefik-external)

--- a/k8s/system/external-dns/values.yaml
+++ b/k8s/system/external-dns/values.yaml
@@ -15,5 +15,5 @@ external-dns:
         secretKeyRef:
           name: cloudflare-credentials
           key: email
-  args:
+  extraArgs:
     - --annotation-filter=kubernetes.io/ingress.class in (traefik-external)

--- a/k8s/system/external-dns/values.yaml
+++ b/k8s/system/external-dns/values.yaml
@@ -5,7 +5,7 @@ external-dns:
   interval: 168h
   triggerLoopOnEvent: true
   env:
-    - name: CF_API_KEY
+    - name: CF_API_TOKEN
       valueFrom:
         secretKeyRef:
           name: cloudflare-credentials


### PR DESCRIPTION
Internal services have a CNAME wildcard to the local IP, when a service needs to be available public, then external-dns can create a CNAME record which overrides the sub-domain.