### PR TITLE
k8s: add annotation to dnsendpoints

### DIFF
--- a/k8s/system/external-dns/templates/records-cname.yml
+++ b/k8s/system/external-dns/templates/records-cname.yml
@@ -3,6 +3,8 @@ apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
   name: "argocd-webhook.fmlab.no"
+  annotations:
+    kubernetes.io/ingress.class: traefik-external # Annotation filters are enabled, will be ignored if removed
 spec:
   endpoints:
     - dnsName: "argocd-webhook.fmlab.no"


### PR DESCRIPTION
Since annotationFilters are enabled, external-dns will ignore all ingress/crd resources that does not match the following rule: `annotationFilter: kubernetes.io/ingress.class in (traefik-external)`