### PR TITLE
ansible: use k8s from 3rd party repo

### DIFF
--- a/ansible/playbooks/k8s-0-packages.yml
+++ b/ansible/playbooks/k8s-0-packages.yml
@@ -10,6 +10,7 @@
     - name: dnf - upgrade latest
       dnf:
         name: "*"
+        update_cache: true
         state: latest
 
     - name: dnf - remove default packages
@@ -26,12 +27,32 @@
           - nut-client
           - power-profiles-daemon
 
-    - name: dnf - install kubernetes packages
+    - name: dnf - install crio and iproute packages
       dnf:
         name:
           - cri-o
           - cri-tools
           - iproute-tc
-          - kubernetes-client
-          - kubernetes-kubeadm
-          - kubernetes-node
+
+    - name: yum - add kubernetes repository
+      ansible.builtin.yum_repository:
+        name: Kubernetes
+        description: Kubernetes
+        baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch
+        enabled: true
+        gpgcheck: true
+        gpgkey: https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+        exclude: kubelet kubeadm kubectl
+
+    # Kubernetes packages should not be upgraded out of sync with a cluster upgrade using kubeadm.
+    # Therefore, use state present and upgrade packages manually during kubeadm upgrade.
+    # https://github.com/kubernetes/kubeadm/issues/954
+    - name: yum - install kubernetes packages
+      ansible.builtin.yum:
+        name:
+          - kubeadm
+          - kubectl
+          - kubelet
+        disable_excludes: Kubernetes
+        update_cache: true
+        state: present

--- a/ansible/playbooks/k8s-1-configuration.yml
+++ b/ansible/playbooks/k8s-1-configuration.yml
@@ -101,6 +101,10 @@
       command: "/usr/bin/hostnamectl --static --pretty --transient set-hostname {{ inventory_hostname | replace('_', '-') | quote }}"
       when: inventory_hostname != ansible_fqdn
 
+    # without this step, old chaced fqdn value will be validated
+    - name: ansible - run setup to refresh ansible_fqdn
+      setup:
+
     - name: hostname - validate ansible_fqdn == inventory_hostname
       tags:
         - validate
@@ -212,7 +216,7 @@
     ## SELinux ##
     #############
 
-    # # SELinux seems to work fine for my setup, leaving it commented until the day it breaks
+    # # Breaks nodefeaturediscovery, hostpathprovisioner, some db's inside containers
     # # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
     # - name: selinux - setenforce 0
     #   command: setenforce 0

--- a/ansible/playbooks/k8s-1-configuration.yml
+++ b/ansible/playbooks/k8s-1-configuration.yml
@@ -216,7 +216,8 @@
     ## SELinux ##
     #############
 
-    # # Breaks nodefeaturediscovery, hostpathprovisioner, some db's inside containers
+    # Will attempt to run with SELinux and just fix the issues as they come up for now.
+    # # Breaks nodefeaturediscovery, hostpathprovisioner, some db's inside containers.
     # # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
     # - name: selinux - setenforce 0
     #   command: setenforce 0

--- a/ansible/playbooks/k8s-3-create-cluster.yml
+++ b/ansible/playbooks/k8s-3-create-cluster.yml
@@ -102,6 +102,11 @@
 
     - name: kubeadm - initialize the Kubernetes cluster
       command: kubeadm init --config /etc/kubernetes/kube-init-config.yaml
+      register: cluster_creation_output
+
+    - name: kubadm - cluster creation output
+      debug:
+        msg: "{{ cluster_creation_output.stdout_lines }}"
 
     - name: ansible - sleep for 45 seconds (wait for cluster startup)
       wait_for:

--- a/ansible/playbooks/k8s-5-kubeconfig.yml
+++ b/ansible/playbooks/k8s-5-kubeconfig.yml
@@ -3,6 +3,9 @@
   become: true
   vars:
     local_user: fredrick
+    interface:
+      private: 10.8.0.10
+      mgmt: 10.8.0.50
 
   tasks:
     - name: kubeadm - create kubeconfig for terraform
@@ -43,7 +46,7 @@
       when: "'k8s_controller' in group_names"
 
     - name: gcpsm - upload kubectl content to new secret version
-      shell: echo {{ kubeconfig_terraform.stdout | quote }} | gcloud secrets versions add --data-file=- homelab-kubeconfig
+      shell: echo {{ kubeconfig_terraform.stdout | quote }} | sed "s/{{ interface.private }}/{{ interface.mgmt }}/g" | gcloud secrets versions add --data-file=- homelab-kubeconfig
       delegate_to: localhost
       become_user: "{{ local_user }}"
       when: "'k8s_controller' in group_names"


### PR DESCRIPTION
Had this amazing idea of using the kubeadm binaries from fedora repositories, as the versions are the same in the 3rd party repository.

HOWEVER, the default configuration in the fedora repositories are wack. One example is the kubelet configuration which is provided by kubeadm, is not used by the systemd service, which will make the kubelet use defaults. So any configuration you make in `KubeletConfiguration` is pretty much ignored.

The official 3rd party yum repository regained my sanity.