### PR TITLE
k8s: add metrics-server

### DIFF
--- a/ansible/playbooks/k8s-2-firewall.yml
+++ b/ansible/playbooks/k8s-2-firewall.yml
@@ -97,8 +97,15 @@
       ansible.posix.firewalld:
         state: enabled
         permanent: true
+        zone: trusted
         source: "{{ item }}"
       loop:
         - "{{ subnet.kubernetes.pod }}"
         - "{{ subnet.kubernetes.svc }}"
         - 10.8.0.0/24 # K8s VLAN
+
+    - name: firewall - reload firewalld service
+      service:
+        name: firewalld
+        enabled: yes
+        state: reloaded

--- a/k8s/monitoring/metrics-server/Chart.yaml
+++ b/k8s/monitoring/metrics-server/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: metrics-server
+description: Container resource metrics for Kubernetes
+
+type: application
+
+version: 1.0.0
+
+dependencies:
+- name: metrics-server
+  version: ^3.8.0
+  repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/k8s/monitoring/metrics-server/values.yaml
+++ b/k8s/monitoring/metrics-server/values.yaml
@@ -1,0 +1,3 @@
+metrics-server:
+  args:
+    - --kubelet-insecure-tls

--- a/k8s/monitoring/prometheus/Chart.yaml
+++ b/k8s/monitoring/prometheus/Chart.yaml
@@ -8,5 +8,8 @@ version: 1.0.0
 
 dependencies:
 - name: kube-prometheus-stack
-  version: 45.7.1
+  version: ^45.7.0
   repository: https://prometheus-community.github.io/helm-charts
+- name: metrics-server
+  version: ^3.8.0
+  repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/k8s/monitoring/prometheus/Chart.yaml
+++ b/k8s/monitoring/prometheus/Chart.yaml
@@ -10,6 +10,3 @@ dependencies:
 - name: kube-prometheus-stack
   version: ^45.7.0
   repository: https://prometheus-community.github.io/helm-charts
-- name: metrics-server
-  version: ^3.8.0
-  repository: https://kubernetes-sigs.github.io/metrics-server/

--- a/k8s/monitoring/prometheus/values.yaml
+++ b/k8s/monitoring/prometheus/values.yaml
@@ -33,3 +33,7 @@ kube-prometheus-stack:
 
   grafana:
     enabled: false
+
+metrics-server:
+  args:
+    - --kubelet-insecure-tls

--- a/k8s/monitoring/prometheus/values.yaml
+++ b/k8s/monitoring/prometheus/values.yaml
@@ -33,7 +33,3 @@ kube-prometheus-stack:
 
   grafana:
     enabled: false
-
-metrics-server:
-  args:
-    - --kubelet-insecure-tls

--- a/k8s/stack.yaml
+++ b/k8s/stack.yaml
@@ -60,6 +60,9 @@ appProject:
       grafana:
         namespace:
           name: monitoring
+      metrics-server:
+        namespace:
+          name: kube-system
       prometheus:
         namespace:
           name: monitoring


### PR DESCRIPTION
Add https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server for collecting k8s metrics with Prometheus.